### PR TITLE
Fix leak in ClientSession::getAcl (FB11988552)

### DIFF
--- a/OSX/libsecurityd/lib/transition.cpp
+++ b/OSX/libsecurityd/lib/transition.cpp
@@ -736,6 +736,7 @@ void ClientSession::getAcl(AclKind kind, GenericHandle key, const char *tag,
 	IPC(ucsp_client_getAcl(UCSP_ARGS, kind, key,
 		(tag != NULL), tag ? tag : "",
 		&count, &info, &infoLength));
+	VMGuard _(info, infoLength);
 
 	CSSM_ACL_ENTRY_INFO_ARRAY_PTR aclsArray;
 	if (!::copyout_chunked(info, infoLength, reinterpret_cast<xdrproc_t>(xdr_CSSM_ACL_ENTRY_INFO_ARRAY_PTR), reinterpret_cast<void**>(&aclsArray)))


### PR DESCRIPTION
The buffer returned by ucsp_client_getAcl needs to be deallocated.